### PR TITLE
Add medical disclaimer overlay for first-time app users

### DIFF
--- a/lib/core/services/disclaimer_service.dart
+++ b/lib/core/services/disclaimer_service.dart
@@ -1,0 +1,28 @@
+import 'package:hive/hive.dart';
+
+class DisclaimerService {
+  static const String _disclaimerBoxName = 'disclaimer_box';
+  static const String _disclaimerAcceptedKey = 'disclaimer_accepted';
+  
+  static Box? _box;
+
+  /// Initialize the disclaimer service
+  static Future<void> init() async {
+    _box = await Hive.openBox(_disclaimerBoxName);
+  }
+
+  /// Check if the user has accepted the disclaimer
+  static bool hasAcceptedDisclaimer() {
+    return _box?.get(_disclaimerAcceptedKey, defaultValue: false) ?? false;
+  }
+
+  /// Mark the disclaimer as accepted
+  static Future<void> acceptDisclaimer() async {
+    await _box?.put(_disclaimerAcceptedKey, true);
+  }
+
+  /// Reset disclaimer acceptance (for testing purposes)
+  static Future<void> resetDisclaimer() async {
+    await _box?.delete(_disclaimerAcceptedKey);
+  }
+}

--- a/lib/core/widgets/disclaimer_overlay.dart
+++ b/lib/core/widgets/disclaimer_overlay.dart
@@ -1,0 +1,265 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../services/disclaimer_service.dart';
+import '../theme/colors.dart';
+import '../theme/tokens.dart';
+import 'buttons.dart';
+
+class DisclaimerOverlay extends StatelessWidget {
+  final VoidCallback onAccepted;
+  
+  const DisclaimerOverlay({
+    super.key,
+    required this.onAccepted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.black80.withOpacity(0.7),
+      child: SafeArea(
+        child: Center(
+          child: Container(
+            margin: const EdgeInsets.all(24),
+            padding: const EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: AppTokens.bgPrimary,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.black40,
+                  blurRadius: 8,
+                  spreadRadius: 0,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Header
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.warning_amber_rounded,
+                        color: AppTokens.stateError,
+                        size: 28,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'Important Disclaimer',
+                          style: TextStyle(
+                            fontFamily: 'Outfit',
+                            fontSize: 22,
+                            fontWeight: FontWeight.bold,
+                            color: AppTokens.textPrimary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  
+                  // Main disclaimer text
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.red[50],
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: AppTokens.stateError.withOpacity(0.4),
+                        width: 1.5,
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'IMPORTANT DISCLAIMER:',
+                          style: TextStyle(
+                            fontFamily: 'Outfit',
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: AppTokens.stateError,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'This app is NOT a medical device and does not claim to improve your mental or physical health in any way. It should NEVER be considered a replacement for professional healthcare providers, licensed therapists, psychiatrists, or medical professionals.',
+                          style: TextStyle(
+                            fontFamily: 'Outfit',
+                            fontSize: 14,
+                            height: 1.5,
+                            color: AppColors.black100,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  
+                  const SizedBox(height: 16),
+                  
+                  // Additional warnings
+                  Text(
+                    'Please note:',
+                    style: TextStyle(
+                      fontFamily: 'Outfit',
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: AppTokens.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  
+                  _buildBulletPoint('Always consult with qualified healthcare providers for medical advice, diagnosis, or treatment'),
+                  _buildBulletPoint('This app is for informational and wellness tracking purposes only'),
+                  _buildBulletPoint('Do not use this app for medical emergencies - contact emergency services immediately'),
+                  _buildBulletPoint('Do not stop or modify prescribed medications without consulting your healthcare provider'),
+                  _buildBulletPoint('If you are experiencing a mental health crisis, contact a mental health professional or crisis hotline'),
+                  
+                  const SizedBox(height: 24),
+                  
+                  // Action buttons
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Button.secondary(
+                          onPressed: () => _onDecline(context),
+                          text: 'I Do Not Agree',
+                          fontSize: 16,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          textColor: AppTokens.stateError,
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        flex: 2,
+                        child: Button.primary(
+                          onPressed: () => _onAccept(context),
+                          text: 'I Understand & Agree',
+                          fontSize: 16,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                        ),
+                      ),
+                    ],
+                  ),
+                  
+                  const SizedBox(height: 16),
+                  
+                  // Footer note
+                  Text(
+                    'By continuing to use this app, you acknowledge that you have read, understood, and agree to this disclaimer.',
+                    style: TextStyle(
+                      fontFamily: 'Outfit',
+                      fontSize: 12,
+                      color: AppColors.black60,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBulletPoint(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            margin: const EdgeInsets.only(top: 8, right: 12),
+            width: 4,
+            height: 4,
+            decoration: BoxDecoration(
+              color: AppColors.black80,
+              shape: BoxShape.circle,
+            ),
+          ),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(
+                fontFamily: 'Outfit',
+                fontSize: 14,
+                height: 1.4,
+                color: AppColors.black80,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onAccept(BuildContext context) async {
+    await DisclaimerService.acceptDisclaimer();
+    onAccepted();
+  }
+
+  void _onDecline(BuildContext context) {
+    // Show confirmation dialog before closing the app
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          backgroundColor: AppTokens.bgPrimary,
+          title: Text(
+            'Exit App',
+            style: TextStyle(
+              fontFamily: 'Outfit',
+              fontWeight: FontWeight.bold,
+              color: AppTokens.textPrimary,
+            ),
+          ),
+          content: Text(
+            'You must accept the disclaimer to use this app. Would you like to exit?',
+            style: TextStyle(
+              fontFamily: 'Outfit',
+              color: AppColors.black80,
+            ),
+          ),
+          actions: [
+            Button.secondary(
+              onPressed: () => Navigator.of(context).pop(),
+              text: 'Review Again',
+              fontSize: 14,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            ),
+            const SizedBox(width: 8),
+            Button.secondary(
+              onPressed: () {
+                // Close the app
+                if (Platform.isAndroid) {
+                  SystemNavigator.pop();
+                } else if (Platform.isIOS) {
+                  // iOS doesn't allow programmatic app termination
+                  // The user will need to manually close the app
+                  Navigator.of(context).pop();
+                }
+              },
+              text: 'Exit App',
+              fontSize: 14,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              textColor: AppTokens.stateError,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/core/widgets/disclaimer_overlay.dart
+++ b/lib/core/widgets/disclaimer_overlay.dart
@@ -17,7 +17,7 @@ class DisclaimerOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: AppColors.black80.withOpacity(0.7),
+      color: AppColors.black80.withValues(alpha: 0.7),
       child: SafeArea(
         child: Center(
           child: Container(
@@ -71,7 +71,7 @@ class DisclaimerOverlay extends StatelessWidget {
                       color: Colors.red[50],
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
-                        color: AppTokens.stateError.withOpacity(0.4),
+                        color: AppTokens.stateError.withValues(alpha: 0.4),
                         width: 1.5,
                       ),
                     ),

--- a/lib/features/splash/splash_screen.dart
+++ b/lib/features/splash/splash_screen.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pretty_animated_text/pretty_animated_text.dart';
+import '../../core/services/disclaimer_service.dart';
+import '../../core/widgets/disclaimer_overlay.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -18,6 +20,8 @@ class _SplashScreenState extends State<SplashScreen>
   late Animation<double> _scaleAnimation;
   late Animation<double> _taglineOpacityAnimation;
   late Animation<double> _taglineSlideAnimation;
+  bool _showDisclaimer = false;
+  bool _animationCompleted = false;
 
   @override
   void initState() {
@@ -67,10 +71,35 @@ class _SplashScreenState extends State<SplashScreen>
     // Wait for the animation to complete
     Timer(const Duration(milliseconds: 2000), () {
       if (mounted) {
-        // Navigate directly to the journal screen
-        context.go('/journal');
+        setState(() {
+          _animationCompleted = true;
+        });
+        _checkDisclaimerAndNavigate();
       }
     });
+  }
+
+  void _checkDisclaimerAndNavigate() {
+    if (!DisclaimerService.hasAcceptedDisclaimer()) {
+      setState(() {
+        _showDisclaimer = true;
+      });
+    } else {
+      _navigateToJournal();
+    }
+  }
+
+  void _navigateToJournal() {
+    if (mounted) {
+      context.go('/journal');
+    }
+  }
+
+  void _onDisclaimerAccepted() {
+    setState(() {
+      _showDisclaimer = false;
+    });
+    _navigateToJournal();
   }
 
   @override
@@ -83,71 +112,82 @@ class _SplashScreenState extends State<SplashScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.pink[50],
-      body: Center(
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (context, child) {
-            return Opacity(
-              opacity: _opacityAnimation.value,
-              child: Transform.scale(
-                scale: _scaleAnimation.value,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    // Logo
-                    Image.asset(
-                      'assets/icons/splash-icon.png',
-                      width: 120,
-                      height: 120,
-                    ),
-                    const SizedBox(height: 24),
-                    // App name
-                    const Text(
-                      'PinkRain',
-                      style: TextStyle(
-                        fontFamily: 'Outfit',
-                        fontSize: 36,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.black87,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-                    // Tagline with enhanced animation
-                    AnimatedBuilder(
-                      animation: _controller,
-                      builder: (context, child) {
-                        return Transform.translate(
-                          offset: Offset(0, _taglineSlideAnimation.value),
-                          child: Opacity(
-                            opacity: _taglineOpacityAnimation.value,
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(vertical: 20),
-                              child: ChimeBellText(
-                                text: "It's time to feel better",
-                                duration: Duration(milliseconds: 700),
-                                type: AnimationType.word,
-                                textStyle: TextStyle(
-                                  fontSize: 18,
-                                  color: Color(0xFF4A4A4A)
-                                )
-                            ),
+      body: Stack(
+        children: [
+          // Main splash content
+          Center(
+            child: AnimatedBuilder(
+              animation: _controller,
+              builder: (context, child) {
+                return Opacity(
+                  opacity: _opacityAnimation.value,
+                  child: Transform.scale(
+                    scale: _scaleAnimation.value,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        // Logo
+                        Image.asset(
+                          'assets/icons/splash-icon.png',
+                          width: 120,
+                          height: 120,
+                        ),
+                        const SizedBox(height: 24),
+                        // App name
+                        const Text(
+                          'PinkRain',
+                          style: TextStyle(
+                            fontFamily: 'Outfit',
+                            fontSize: 36,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.black87,
                           ),
-                        )
-                        );
-                      },
+                        ),
+                        const SizedBox(height: 20),
+                        // Tagline with enhanced animation
+                        AnimatedBuilder(
+                          animation: _controller,
+                          builder: (context, child) {
+                            return Transform.translate(
+                              offset: Offset(0, _taglineSlideAnimation.value),
+                              child: Opacity(
+                                opacity: _taglineOpacityAnimation.value,
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(vertical: 20),
+                                  child: ChimeBellText(
+                                    text: "It's time to feel better",
+                                    duration: Duration(milliseconds: 700),
+                                    type: AnimationType.word,
+                                    textStyle: TextStyle(
+                                      fontSize: 18,
+                                      color: Color(0xFF4A4A4A)
+                                    )
+                                ),
+                              ),
+                            )
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 48),
+                        // Loading indicator (only show if disclaimer is not shown)
+                        if (!_showDisclaimer)
+                          const CircularProgressIndicator(
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                            strokeWidth: 3,
+                          ),
+                      ],
                     ),
-                    const SizedBox(height: 48),
-                    // Loading indicator
-                    const CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                      strokeWidth: 3,
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
+                  ),
+                );
+              },
+            ),
+          ),
+          // Disclaimer overlay
+          if (_showDisclaimer && _animationCompleted)
+            DisclaimerOverlay(
+              onAccepted: _onDisclaimerAccepted,
+            ),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/navigation/router.dart';
 import 'core/services/hive_service.dart';
+import 'core/services/disclaimer_service.dart';
 import 'features/treatment/services/daily_reset_service.dart';
 import 'features/treatment/services/medication_notification_service.dart';
 
@@ -11,6 +12,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await HiveService.init();
+  await DisclaimerService.init();
   
   // Initialize notification service at app startup
   final notificationService = MedicationNotificationService();


### PR DESCRIPTION
- Create DisclaimerService to track user acceptance using Hive storage
- Add DisclaimerOverlay widget with professional medical disclaimer
- Integrate disclaimer into splash screen flow for first launch only
- Use PinkRain design system colors, typography, and button components
- Include comprehensive medical safety warnings and liability disclaimers
- Handle user acceptance/decline with proper app exit flow
- Ensure high text contrast for accessibility and legal compliance
- Persist disclaimer acceptance across app sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a disclaimer flow shown after the splash animation, blocking navigation until addressed.
  * New modal disclaimer overlay with warnings, bullet points, and two actions: “I Do Not Agree” (prompts to close the app) and “I Understand & Agree” (continues into the app).
  * Acceptance is persisted so the disclaimer is not shown again on subsequent launches.
  * Disclaimer state is initialized at app startup to ensure correct navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->