### PR TITLE
feat: add JSON export/import for cross-device data migration

### DIFF
--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -165,14 +165,14 @@ class DataTransferService {
   }
 
   /// Reject malformed exports up-front so we never enter the wipe path on
-  /// bad input. Lenient about missing boxes (treated as empty — local box is
-  /// cleared by [HiveService.importAllBoxes], which matches the user's
-  /// "source device had no data for this box" intent) but strict about
-  /// everything else:
+  /// bad input.
   ///
-  ///   - present-but-non-Map box wrappers are rejected (otherwise
-  ///     `HiveService.importAllBoxes` would clear the local box and skip
-  ///     repopulation, silently destroying user data);
+  ///   - every box in [HiveService.exportableBoxNames] must be present and
+  ///     a Map (possibly empty). `HiveService.exportAllBoxes` always writes
+  ///     all six wrappers, so a missing key means the file was truncated or
+  ///     hand-edited — and accepting it would let
+  ///     `HiveService.importAllBoxes` clear the local box and skip
+  ///     repopulation, silently destroying user data;
   ///   - every field `Treatment.fromJson` and
   ///     `MedicineInventorySerialization.fromJson` cast — including the
   ///     optional `doseTimes`/`doseNamesMap`/`selectedDays` — is type-checked,
@@ -180,10 +180,13 @@ class DataTransferService {
   ///     placeholder objects, which would silently replace the user's real
   ///     data after Hive is already wiped.
   static void _spotCheckShapes(Map<String, dynamic> boxes) {
-    // 1. Every present box wrapper must be a Map (matching what
-    //    HiveService.exportAllBoxes produces).
+    // 1. Every exportable box must be present and a Map.
     for (final boxName in HiveService.exportableBoxNames) {
-      if (boxes.containsKey(boxName) && boxes[boxName] is! Map) {
+      if (!boxes.containsKey(boxName)) {
+        throw DataImportException(
+            'Export file is missing the "$boxName" box. It may be truncated or corrupted.');
+      }
+      if (boxes[boxName] is! Map) {
         throw DataImportException(
             'Box "$boxName" must be a map (got ${boxes[boxName].runtimeType}).');
       }
@@ -303,6 +306,14 @@ class DataTransferService {
       if (selectedDays is! List) {
         throw DataImportException(
             '"treatmentPlan.selectedDays" in treatment #${index + 1} must be a list (got ${selectedDays.runtimeType}).');
+      }
+      // Must be exactly 7 — TreatmentPlan.shouldTakeOnDate indexes by
+      // weekday 0..6 (treatment.dart:82). A shorter list throws RangeError
+      // the next time the journal computes today's doses, after the import
+      // dialog has already closed.
+      if (selectedDays.length != 7) {
+        throw DataImportException(
+            '"treatmentPlan.selectedDays" in treatment #${index + 1} must have exactly 7 entries (got ${selectedDays.length}).');
       }
       for (var j = 0; j < selectedDays.length; j++) {
         if (selectedDays[j] is! bool) {

--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -301,7 +301,11 @@ class DataTransferService {
         throw DataImportException(
             'symptomData["$label"] must be a map (got ${value.runtimeType}).');
       }
-      _requireString(value['date'], 'date', 'symptomData["$label"]');
+      // `getSymptomEntries` does `DateTime.parse(entry['date'])` inside a
+      // loop wrapped in `try/catch` that returns `[]` — so a single
+      // unparseable date silently drops ALL symptom data forever, not just
+      // the bad entry. Validate parseability, not just string-ness.
+      _requireDateString(value['date'], 'date', 'symptomData["$label"]');
       final symptoms = value['symptoms'];
       if (symptoms is! List) {
         throw DataImportException(
@@ -316,11 +320,15 @@ class DataTransferService {
     }
   }
 
-  /// `IntakeLog.fromMap` is intentionally defensive about per-field types
-  /// (silently substitutes "Unknown Medicine" / `0.0` dosage / etc.), so
-  /// we don't replicate its full type ladder. But we do enforce that the
-  /// container shape is a List of Maps — anything else would either crash
-  /// the loader or generate a screen full of placeholder rows.
+  /// `IntakeLog.fromMap` is intentionally defensive about per-field types,
+  /// silently substituting "Unknown Medicine" / `0.0` dosage / `false` /
+  /// `DateTime.now()` for missing or wrong-typed fields. That defensiveness
+  /// is exactly the silent-corruption mode we cannot accept here: a
+  /// hand-edited export with `dosage: "ten"` would import without error and
+  /// then quietly become `dosage: 1.0` in the user's history. So we
+  /// validate every field `IntakeLog.toMap` writes, strictly to the type
+  /// the writer produces. `dose_time` is the only field allowed to be null
+  /// or missing (it's optional for legacy single-dose treatments).
   static void _validateMedicationLogs(Map box) {
     for (final entry in box.entries) {
       final key = entry.key;
@@ -335,7 +343,32 @@ class DataTransferService {
           throw DataImportException(
               'medicationLogs["$label"][$i] must be a map (got ${value[i].runtimeType}).');
         }
+        _validateMedicationLogEntry(value[i] as Map, label, i);
       }
+    }
+  }
+
+  static void _validateMedicationLogEntry(Map row, String key, int index) {
+    final location = 'medicationLogs["$key"][$index]';
+    _requireString(row['treatment_id'], 'treatment_id', location);
+    _requireString(row['medicine_name'], 'medicine_name', location);
+    _requireString(row['medicine_type'], 'medicine_type', location);
+    _requireString(row['medicine_color'], 'medicine_color', location);
+    _requireNum(row['dosage'], 'dosage', location);
+    _requireString(row['unit'], 'unit', location);
+    _requireDateString(row['treatment_plan_start_date'],
+        'treatment_plan_start_date', location);
+    _requireDateString(row['treatment_plan_end_date'],
+        'treatment_plan_end_date', location);
+    _requireBool(row['is_taken'], 'is_taken', location);
+    _requireBool(row['is_skipped'], 'is_skipped', location);
+
+    // dose_time is the one optional field: null/missing is legitimate
+    // (single-dose treatments from older app versions). If present, must
+    // be a parseable ISO-8601 string.
+    final doseTime = row['dose_time'];
+    if (doseTime != null) {
+      _requireDateString(doseTime, 'dose_time', location);
     }
   }
 
@@ -495,6 +528,13 @@ class DataTransferService {
     if (value is! int) {
       throw DataImportException(
           '"$field" in $location must be an integer (got ${value.runtimeType}).');
+    }
+  }
+
+  static void _requireBool(dynamic value, String field, String location) {
+    if (value is! bool) {
+      throw DataImportException(
+          '"$field" in $location must be a boolean (got ${value.runtimeType}).');
     }
   }
 

--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -173,12 +173,15 @@ class DataTransferService {
   ///     hand-edited — and accepting it would let
   ///     `HiveService.importAllBoxes` clear the local box and skip
   ///     repopulation, silently destroying user data;
-  ///   - every field `Treatment.fromJson` and
-  ///     `MedicineInventorySerialization.fromJson` cast — including the
-  ///     optional `doseTimes`/`doseNamesMap`/`selectedDays` — is type-checked,
-  ///     because both readers catch their own parse failures and fall back to
-  ///     placeholder objects, which would silently replace the user's real
-  ///     data after Hive is already wiped.
+  ///   - every payload shape that a downstream reader will eventually cast
+  ///     is type-checked here. The principle is: since import is destructive,
+  ///     no badly-typed value gets past validation. Readers fall into two
+  ///     groups — the strict ones (`Treatment.fromJson`,
+  ///     `getUserMood`/`getUserName`, the `as int`/`as String` casts in
+  ///     `wellness_screen.dart`) crash on a wrong type, which would hit the
+  ///     user the instant they land on /wellness after import; the defensive
+  ///     ones (`IntakeLog.fromMap`) silently substitute placeholders, which
+  ///     is even worse because the user can't tell their data is gone.
   static void _spotCheckShapes(Map<String, dynamic> boxes) {
     // 1. Every exportable box must be present and a Map.
     for (final boxName in HiveService.exportableBoxNames) {
@@ -192,30 +195,145 @@ class DataTransferService {
       }
     }
 
-    final treatmentsBox = boxes[HiveService.treatmentsBoxName];
-    if (treatmentsBox is Map) {
-      final list = treatmentsBox['treatments'];
-      if (list != null && list is! List) {
-        throw const DataImportException(
-            'Export file is malformed: "treatments" should be a list.');
-      }
-      if (list is List) {
-        for (var i = 0; i < list.length; i++) {
-          _validateTreatmentEntry(list[i], i);
-        }
+    _validateUserPreferences(boxes[HiveService.userPrefsBox] as Map);
+    _validateMoodData(boxes[HiveService.moodBoxName] as Map);
+    _validateSymptomData(boxes[HiveService.symptomBoxName] as Map);
+    _validateMedicationLogs(boxes[HiveService.medicationLogsBoxName] as Map);
+
+    final treatmentsBox = boxes[HiveService.treatmentsBoxName] as Map;
+    final treatmentsList = treatmentsBox['treatments'];
+    if (treatmentsList != null && treatmentsList is! List) {
+      throw const DataImportException(
+          'Export file is malformed: "treatments" should be a list.');
+    }
+    if (treatmentsList is List) {
+      for (var i = 0; i < treatmentsList.length; i++) {
+        _validateTreatmentEntry(treatmentsList[i], i);
       }
     }
 
-    final pillboxBox = boxes[HiveService.pillboxBoxName];
-    if (pillboxBox is Map) {
-      final list = pillboxBox['pillbox'];
-      if (list != null && list is! List) {
-        throw const DataImportException(
-            'Export file is malformed: "pillbox" should be a list.');
+    final pillboxBox = boxes[HiveService.pillboxBoxName] as Map;
+    final pillboxList = pillboxBox['pillbox'];
+    if (pillboxList != null && pillboxList is! List) {
+      throw const DataImportException(
+          'Export file is malformed: "pillbox" should be a list.');
+    }
+    if (pillboxList is List) {
+      for (var i = 0; i < pillboxList.length; i++) {
+        _validatePillboxEntry(pillboxList[i], i);
       }
-      if (list is List) {
-        for (var i = 0; i < list.length; i++) {
-          _validatePillboxEntry(list[i], i);
+    }
+  }
+
+  /// `getUserMood` / `getUserName` etc. have `Future<int>` / `Future<String>`
+  /// return types — a wrong-typed value in Hive triggers a TypeError on
+  /// the implicit cast at the await boundary. Strict on the four known
+  /// keys; unknown keys are accepted (forward compat).
+  static void _validateUserPreferences(Map box) {
+    for (final entry in box.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      if (key is! String) continue;
+      switch (key) {
+        case 'userMood':
+          if (value is! int) {
+            throw DataImportException(
+                '"userPreferences.userMood" must be an integer (got ${value.runtimeType}).');
+          }
+          break;
+        case 'userName':
+        case 'userMoodDescription':
+        case 'lastMoodDate':
+          if (value is! String) {
+            throw DataImportException(
+                '"userPreferences.$key" must be a string (got ${value.runtimeType}).');
+          }
+          break;
+      }
+    }
+  }
+
+  /// `wellness_screen.dart:201` casts mood as int. `getMoodEntriesForDate`
+  /// handles two value shapes for back-compat: a single Map (legacy) or a
+  /// List of Maps. We accept both, and inside each entry validate the three
+  /// fields that downstream code reads.
+  static void _validateMoodData(Map box) {
+    for (final entry in box.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      final label = key is String ? key : key.toString();
+      if (value is Map) {
+        _validateMoodEntry(value, label, 0);
+      } else if (value is List) {
+        for (var i = 0; i < value.length; i++) {
+          if (value[i] is! Map) {
+            throw DataImportException(
+                'moodData["$label"][$i] must be a map (got ${value[i].runtimeType}).');
+          }
+          _validateMoodEntry(value[i] as Map, label, i);
+        }
+      } else {
+        throw DataImportException(
+            'moodData["$label"] must be a list or map (got ${value.runtimeType}).');
+      }
+    }
+  }
+
+  static void _validateMoodEntry(Map entry, String key, int index) {
+    final location = 'moodData["$key"][$index]';
+    final mood = entry['mood'];
+    if (mood is! int) {
+      throw DataImportException(
+          '"mood" in $location must be an integer (got ${mood.runtimeType}).');
+    }
+    _requireString(entry['description'], 'description', location);
+    _requireDateString(entry['timestamp'], 'timestamp', location);
+  }
+
+  /// `getSymptomEntries` does `List<String>.from(entry['symptoms'])` and
+  /// `DateTime.parse(entry['date'])`. Both throw on type mismatch.
+  static void _validateSymptomData(Map box) {
+    for (final entry in box.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      final label = key is String ? key : key.toString();
+      if (value is! Map) {
+        throw DataImportException(
+            'symptomData["$label"] must be a map (got ${value.runtimeType}).');
+      }
+      _requireString(value['date'], 'date', 'symptomData["$label"]');
+      final symptoms = value['symptoms'];
+      if (symptoms is! List) {
+        throw DataImportException(
+            '"symptoms" in symptomData["$label"] must be a list (got ${symptoms.runtimeType}).');
+      }
+      for (var i = 0; i < symptoms.length; i++) {
+        if (symptoms[i] is! String) {
+          throw DataImportException(
+              '"symptoms[$i]" in symptomData["$label"] must be a string (got ${symptoms[i].runtimeType}).');
+        }
+      }
+    }
+  }
+
+  /// `IntakeLog.fromMap` is intentionally defensive about per-field types
+  /// (silently substitutes "Unknown Medicine" / `0.0` dosage / etc.), so
+  /// we don't replicate its full type ladder. But we do enforce that the
+  /// container shape is a List of Maps — anything else would either crash
+  /// the loader or generate a screen full of placeholder rows.
+  static void _validateMedicationLogs(Map box) {
+    for (final entry in box.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      final label = key is String ? key : key.toString();
+      if (value is! List) {
+        throw DataImportException(
+            'medicationLogs["$label"] must be a list (got ${value.runtimeType}).');
+      }
+      for (var i = 0; i < value.length; i++) {
+        if (value[i] is! Map) {
+          throw DataImportException(
+              'medicationLogs["$label"][$i] must be a map (got ${value[i].runtimeType}).');
         }
       }
     }

--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -165,12 +165,30 @@ class DataTransferService {
   }
 
   /// Reject malformed exports up-front so we never enter the wipe path on
-  /// bad input. Lenient about missing boxes (treated as empty) but strict
-  /// about every field `Treatment.fromJson` and `MedicineInventorySerialization.fromJson`
-  /// require — both catch their own parse failures and fall back to
-  /// placeholder objects, which would silently replace the user's real data
-  /// after we've already wiped Hive.
+  /// bad input. Lenient about missing boxes (treated as empty — local box is
+  /// cleared by [HiveService.importAllBoxes], which matches the user's
+  /// "source device had no data for this box" intent) but strict about
+  /// everything else:
+  ///
+  ///   - present-but-non-Map box wrappers are rejected (otherwise
+  ///     `HiveService.importAllBoxes` would clear the local box and skip
+  ///     repopulation, silently destroying user data);
+  ///   - every field `Treatment.fromJson` and
+  ///     `MedicineInventorySerialization.fromJson` cast — including the
+  ///     optional `doseTimes`/`doseNamesMap`/`selectedDays` — is type-checked,
+  ///     because both readers catch their own parse failures and fall back to
+  ///     placeholder objects, which would silently replace the user's real
+  ///     data after Hive is already wiped.
   static void _spotCheckShapes(Map<String, dynamic> boxes) {
+    // 1. Every present box wrapper must be a Map (matching what
+    //    HiveService.exportAllBoxes produces).
+    for (final boxName in HiveService.exportableBoxNames) {
+      if (boxes.containsKey(boxName) && boxes[boxName] is! Map) {
+        throw DataImportException(
+            'Box "$boxName" must be a map (got ${boxes[boxName].runtimeType}).');
+      }
+    }
+
     final treatmentsBox = boxes[HiveService.treatmentsBoxName];
     if (treatmentsBox is Map) {
       final list = treatmentsBox['treatments'];
@@ -248,6 +266,51 @@ class DataTransferService {
         'treatment #${index + 1}');
 
     _requireString(entry['notes'], 'notes', 'treatment #${index + 1}');
+
+    // Optional fields. Treatment.fromJson tolerates them being absent, but
+    // if present each one is cast/parsed and would crash → "Error Treatment"
+    // fallback. Validate everything that's actually there.
+    final doseTimes = plan['doseTimes'];
+    if (doseTimes != null) {
+      if (doseTimes is! List) {
+        throw DataImportException(
+            '"treatmentPlan.doseTimes" in treatment #${index + 1} must be a list (got ${doseTimes.runtimeType}).');
+      }
+      for (var j = 0; j < doseTimes.length; j++) {
+        _requireDateString(doseTimes[j], 'treatmentPlan.doseTimes[$j]',
+            'treatment #${index + 1}');
+      }
+    }
+
+    final doseNamesMap = plan['doseNamesMap'];
+    if (doseNamesMap != null) {
+      if (doseNamesMap is! Map) {
+        throw DataImportException(
+            '"treatmentPlan.doseNamesMap" in treatment #${index + 1} must be a map (got ${doseNamesMap.runtimeType}).');
+      }
+      doseNamesMap.forEach((name, time) {
+        if (name is! String) {
+          throw DataImportException(
+              '"treatmentPlan.doseNamesMap" in treatment #${index + 1} has a non-string key.');
+        }
+        _requireDateString(time, 'treatmentPlan.doseNamesMap["$name"]',
+            'treatment #${index + 1}');
+      });
+    }
+
+    final selectedDays = plan['selectedDays'];
+    if (selectedDays != null) {
+      if (selectedDays is! List) {
+        throw DataImportException(
+            '"treatmentPlan.selectedDays" in treatment #${index + 1} must be a list (got ${selectedDays.runtimeType}).');
+      }
+      for (var j = 0; j < selectedDays.length; j++) {
+        if (selectedDays[j] is! bool) {
+          throw DataImportException(
+              '"treatmentPlan.selectedDays[$j]" in treatment #${index + 1} must be a boolean (got ${selectedDays[j].runtimeType}).');
+        }
+      }
+    }
   }
 
   /// Mirrors `MedicineInventorySerialization.fromJson` + nested

--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -82,29 +82,7 @@ class DataTransferService {
           'File is not valid JSON. Please choose a PinkRain export file.');
     }
 
-    if (decoded is! Map<String, dynamic>) {
-      throw const DataImportException(
-          'Unexpected file format. Please choose a PinkRain export file.');
-    }
-
-    if (decoded['schema'] != schemaTag) {
-      throw const DataImportException(
-          'This does not look like a PinkRain export file.');
-    }
-
-    final fileVersion = decoded['version'];
-    if (fileVersion != schemaVersion) {
-      throw DataImportException(
-          'Unsupported export version ($fileVersion). This app expects version $schemaVersion.');
-    }
-
-    final boxes = decoded['boxes'];
-    if (boxes is! Map<String, dynamic>) {
-      throw const DataImportException(
-          'Export file is missing the "boxes" section.');
-    }
-
-    _spotCheckShapes(boxes);
+    final boxes = validateEnvelope(decoded);
 
     // 1. Cancel any scheduled system notifications before we wipe the
     //    scheduler box (this also clears that box via resetScheduledNotifications).
@@ -155,10 +133,43 @@ class DataTransferService {
     devPrint('✅ Import complete');
   }
 
-  /// Reject obviously malformed exports up-front so we never enter the wipe
-  /// path on bad input. Lenient about missing boxes (treated as empty) but
-  /// strict about the shape of present treatments since `Treatment.fromJson`
-  /// is the most fragile downstream reader.
+  /// Validate a parsed export envelope without touching any state. Returns
+  /// the validated `boxes` map. Throws [DataImportException] on the same
+  /// conditions [importFromFile] would. Lifted out so the destructive path
+  /// in [importFromFile] runs only after this returns cleanly.
+  static Map<String, dynamic> validateEnvelope(dynamic decoded) {
+    if (decoded is! Map<String, dynamic>) {
+      throw const DataImportException(
+          'Unexpected file format. Please choose a PinkRain export file.');
+    }
+
+    if (decoded['schema'] != schemaTag) {
+      throw const DataImportException(
+          'This does not look like a PinkRain export file.');
+    }
+
+    final fileVersion = decoded['version'];
+    if (fileVersion != schemaVersion) {
+      throw DataImportException(
+          'Unsupported export version ($fileVersion). This app expects version $schemaVersion.');
+    }
+
+    final boxes = decoded['boxes'];
+    if (boxes is! Map<String, dynamic>) {
+      throw const DataImportException(
+          'Export file is missing the "boxes" section.');
+    }
+
+    _spotCheckShapes(boxes);
+    return boxes;
+  }
+
+  /// Reject malformed exports up-front so we never enter the wipe path on
+  /// bad input. Lenient about missing boxes (treated as empty) but strict
+  /// about every field `Treatment.fromJson` and `MedicineInventorySerialization.fromJson`
+  /// require — both catch their own parse failures and fall back to
+  /// placeholder objects, which would silently replace the user's real data
+  /// after we've already wiped Hive.
   static void _spotCheckShapes(Map<String, dynamic> boxes) {
     final treatmentsBox = boxes[HiveService.treatmentsBoxName];
     if (treatmentsBox is Map) {
@@ -168,16 +179,8 @@ class DataTransferService {
             'Export file is malformed: "treatments" should be a list.');
       }
       if (list is List) {
-        for (final entry in list) {
-          if (entry is! Map) {
-            throw const DataImportException(
-                'Export file is malformed: a treatment entry is not an object.');
-          }
-          if (entry['medicine'] is! Map ||
-              entry['treatmentPlan'] is! Map) {
-            throw const DataImportException(
-                'Export file is malformed: a treatment is missing required fields.');
-          }
+        for (var i = 0; i < list.length; i++) {
+          _validateTreatmentEntry(list[i], i);
         }
       }
     }
@@ -189,6 +192,129 @@ class DataTransferService {
         throw const DataImportException(
             'Export file is malformed: "pillbox" should be a list.');
       }
+      if (list is List) {
+        for (var i = 0; i < list.length; i++) {
+          _validatePillboxEntry(list[i], i);
+        }
+      }
+    }
+  }
+
+  /// Mirrors every cast/parse in `Treatment.fromJson`
+  /// (lib/features/treatment/domain/treatment_manager.dart:67-150).
+  static void _validateTreatmentEntry(dynamic entry, int index) {
+    if (entry is! Map) {
+      throw DataImportException(
+          'Treatment #${index + 1} is not an object.');
+    }
+    final medicine = entry['medicine'];
+    final plan = entry['treatmentPlan'];
+    if (medicine is! Map) {
+      throw DataImportException(
+          'Treatment #${index + 1} is missing "medicine".');
+    }
+    if (plan is! Map) {
+      throw DataImportException(
+          'Treatment #${index + 1} is missing "treatmentPlan".');
+    }
+
+    _requireString(medicine['name'], 'medicine.name', 'treatment #${index + 1}');
+    _requireString(medicine['type'], 'medicine.type', 'treatment #${index + 1}');
+    _requireString(medicine['color'], 'medicine.color', 'treatment #${index + 1}');
+
+    final spec = medicine['specification'];
+    if (spec is! Map) {
+      throw DataImportException(
+          'Treatment #${index + 1} is missing "medicine.specification".');
+    }
+    _requireNum(spec['dosage'], 'medicine.specification.dosage',
+        'treatment #${index + 1}');
+    _requireString(
+        spec['unit'], 'medicine.specification.unit', 'treatment #${index + 1}');
+    _requireString(spec['useCase'], 'medicine.specification.useCase',
+        'treatment #${index + 1}');
+
+    _requireDateString(plan['startDate'], 'treatmentPlan.startDate',
+        'treatment #${index + 1}');
+    _requireDateString(
+        plan['endDate'], 'treatmentPlan.endDate', 'treatment #${index + 1}');
+    _requireDateString(plan['timeOfDay'], 'treatmentPlan.timeOfDay',
+        'treatment #${index + 1}');
+    _requireString(plan['mealOption'], 'treatmentPlan.mealOption',
+        'treatment #${index + 1}');
+    _requireString(plan['instructions'], 'treatmentPlan.instructions',
+        'treatment #${index + 1}');
+    _requireInt(plan['frequency'], 'treatmentPlan.frequency',
+        'treatment #${index + 1}');
+
+    _requireString(entry['notes'], 'notes', 'treatment #${index + 1}');
+  }
+
+  /// Mirrors `MedicineInventorySerialization.fromJson` + nested
+  /// `MedicineSerialization.fromJson` and `SpecificationSerialization.fromJson`
+  /// (lib/features/pillbox/data/pillbox_model.dart:80-115). Note: this box
+  /// uses the key `specs` (not `specification`).
+  static void _validatePillboxEntry(dynamic entry, int index) {
+    if (entry is! Map) {
+      throw DataImportException(
+          'Pillbox entry #${index + 1} is not an object.');
+    }
+    final medicine = entry['medicine'];
+    if (medicine is! Map) {
+      throw DataImportException(
+          'Pillbox entry #${index + 1} is missing "medicine".');
+    }
+    _requireInt(entry['quantity'], 'quantity', 'pillbox entry #${index + 1}');
+
+    _requireString(
+        medicine['name'], 'medicine.name', 'pillbox entry #${index + 1}');
+    _requireString(
+        medicine['type'], 'medicine.type', 'pillbox entry #${index + 1}');
+    _requireString(
+        medicine['color'], 'medicine.color', 'pillbox entry #${index + 1}');
+
+    final specs = medicine['specs'];
+    if (specs is! Map) {
+      throw DataImportException(
+          'Pillbox entry #${index + 1} is missing "medicine.specs".');
+    }
+    _requireNum(specs['dosage'], 'medicine.specs.dosage',
+        'pillbox entry #${index + 1}');
+    _requireString(
+        specs['unit'], 'medicine.specs.unit', 'pillbox entry #${index + 1}');
+    // useCase is optional in SpecificationSerialization (defaults to '').
+  }
+
+  static void _requireString(dynamic value, String field, String location) {
+    if (value is! String) {
+      throw DataImportException(
+          '"$field" in $location must be a string (got ${value.runtimeType}).');
+    }
+  }
+
+  static void _requireNum(dynamic value, String field, String location) {
+    if (value is! num) {
+      throw DataImportException(
+          '"$field" in $location must be a number (got ${value.runtimeType}).');
+    }
+  }
+
+  static void _requireInt(dynamic value, String field, String location) {
+    if (value is! int) {
+      throw DataImportException(
+          '"$field" in $location must be an integer (got ${value.runtimeType}).');
+    }
+  }
+
+  static void _requireDateString(
+      dynamic value, String field, String location) {
+    if (value is! String) {
+      throw DataImportException(
+          '"$field" in $location must be an ISO-8601 date string (got ${value.runtimeType}).');
+    }
+    if (DateTime.tryParse(value) == null) {
+      throw DataImportException(
+          '"$field" in $location is not a valid date: "$value".');
     }
   }
 }

--- a/lib/core/services/data_transfer_service.dart
+++ b/lib/core/services/data_transfer_service.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:hive/hive.dart';
+import 'package:intl/intl.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pinkrain/core/services/hive_service.dart';
+import 'package:pinkrain/core/util/helpers.dart';
+import 'package:pinkrain/features/journal/data/journal_log.dart';
+import 'package:pinkrain/features/treatment/services/medication_notification_service.dart';
+import 'package:pinkrain/features/treatment/services/medication_scheduler_service.dart';
+
+/// Serializes all user data to a single JSON file and restores it on import.
+///
+/// Exported boxes are the six in [HiveService.exportableBoxNames]. Device-
+/// specific boxes (`medication_scheduler`, `medication_actions`) and
+/// `disclaimer_box` are intentionally excluded; the scheduler is cleared and
+/// rebuilt from the imported treatments at the end of [importFromFile].
+class DataTransferService {
+  DataTransferService._();
+
+  static const String schemaTag = 'pinkrain-export';
+  static const int schemaVersion = 1;
+
+  // Hive box of per-medication status (snooze timestamps etc.) — wiped on
+  // import because the timestamps are bound to the previous device's clock.
+  // The scheduler box (`medication_scheduler`) is cleared transitively by
+  // MedicationSchedulerService.cancelAllNotifications().
+  static const String _actionsBoxName = 'medication_actions';
+
+  /// Write the export JSON to a temporary file and return its path.
+  /// The caller is responsible for sharing/saving the file.
+  static Future<String> exportToFile() async {
+    final boxes = await HiveService.exportAllBoxes();
+    String appVersion = '';
+    try {
+      final info = await PackageInfo.fromPlatform();
+      appVersion = '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      // Non-fatal: the version label is informational only.
+    }
+
+    final envelope = <String, dynamic>{
+      'schema': schemaTag,
+      'version': schemaVersion,
+      'appVersion': appVersion,
+      'exportedAt': DateTime.now().toUtc().toIso8601String(),
+      'boxes': boxes,
+    };
+
+    final payload = jsonEncode(envelope);
+    final dir = await getTemporaryDirectory();
+    final stamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+    final file = File('${dir.path}/pinkrain_export_$stamp.json');
+    await file.writeAsString(payload);
+    devPrint('📤 Wrote export (${payload.length} bytes) to ${file.path}');
+    return file.path;
+  }
+
+  /// Read, validate, and apply an export file. Replaces all user data on
+  /// success. Throws [DataImportException] with a user-facing message on any
+  /// validation or I/O error.
+  static Future<void> importFromFile(String path) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      throw const DataImportException('Selected file does not exist.');
+    }
+
+    final String raw;
+    try {
+      raw = await file.readAsString();
+    } catch (e) {
+      throw DataImportException('Could not read the file: $e');
+    }
+
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (_) {
+      throw const DataImportException(
+          'File is not valid JSON. Please choose a PinkRain export file.');
+    }
+
+    if (decoded is! Map<String, dynamic>) {
+      throw const DataImportException(
+          'Unexpected file format. Please choose a PinkRain export file.');
+    }
+
+    if (decoded['schema'] != schemaTag) {
+      throw const DataImportException(
+          'This does not look like a PinkRain export file.');
+    }
+
+    final fileVersion = decoded['version'];
+    if (fileVersion != schemaVersion) {
+      throw DataImportException(
+          'Unsupported export version ($fileVersion). This app expects version $schemaVersion.');
+    }
+
+    final boxes = decoded['boxes'];
+    if (boxes is! Map<String, dynamic>) {
+      throw const DataImportException(
+          'Export file is missing the "boxes" section.');
+    }
+
+    _spotCheckShapes(boxes);
+
+    // 1. Cancel any scheduled system notifications before we wipe the
+    //    scheduler box (this also clears that box via resetScheduledNotifications).
+    try {
+      await MedicationSchedulerService().cancelAllNotifications();
+    } catch (e) {
+      devPrint('⚠️ cancelAllNotifications failed during import: $e');
+      // Continue — stale notifications are a nuisance, not a blocker.
+    }
+
+    // 2. Clear the action-status box (snooze timestamps are tied to the old device).
+    try {
+      final actionsBox = await Hive.openBox(_actionsBoxName);
+      await actionsBox.clear();
+    } catch (e) {
+      devPrint('⚠️ Could not clear $_actionsBoxName: $e');
+    }
+
+    // 3. Replace user-data boxes. This is the only step that mutates the
+    //    user-visible state; everything before is cleanup, everything after
+    //    is re-derivation.
+    await HiveService.importAllBoxes(boxes);
+
+    // 4. Re-schedule notifications from the freshly imported treatments,
+    //    mirroring the startup flow in main.dart.
+    try {
+      final notificationService = MedicationNotificationService();
+      await notificationService.initialize();
+      notificationService.clearAllNotificationTracking();
+
+      final journalLog = JournalLog();
+      final today = DateTime.now().normalize();
+      final todayMeds =
+          await journalLog.getMedicationsForTheDay(today, forceReload: true);
+      final untaken =
+          todayMeds.where((m) => !m.isTaken && !m.isSkipped).toList();
+
+      await notificationService.showUntakenMedicationNotifications(
+        untaken,
+        forceReschedule: true,
+        showImmediateNotifications: false,
+      );
+    } catch (e) {
+      devPrint('⚠️ Re-scheduling notifications after import failed: $e');
+      // Data is already imported — surface a warning but don't roll back.
+    }
+
+    devPrint('✅ Import complete');
+  }
+
+  /// Reject obviously malformed exports up-front so we never enter the wipe
+  /// path on bad input. Lenient about missing boxes (treated as empty) but
+  /// strict about the shape of present treatments since `Treatment.fromJson`
+  /// is the most fragile downstream reader.
+  static void _spotCheckShapes(Map<String, dynamic> boxes) {
+    final treatmentsBox = boxes[HiveService.treatmentsBoxName];
+    if (treatmentsBox is Map) {
+      final list = treatmentsBox['treatments'];
+      if (list != null && list is! List) {
+        throw const DataImportException(
+            'Export file is malformed: "treatments" should be a list.');
+      }
+      if (list is List) {
+        for (final entry in list) {
+          if (entry is! Map) {
+            throw const DataImportException(
+                'Export file is malformed: a treatment entry is not an object.');
+          }
+          if (entry['medicine'] is! Map ||
+              entry['treatmentPlan'] is! Map) {
+            throw const DataImportException(
+                'Export file is malformed: a treatment is missing required fields.');
+          }
+        }
+      }
+    }
+
+    final pillboxBox = boxes[HiveService.pillboxBoxName];
+    if (pillboxBox is Map) {
+      final list = pillboxBox['pillbox'];
+      if (list != null && list is! List) {
+        throw const DataImportException(
+            'Export file is malformed: "pillbox" should be a list.');
+      }
+    }
+  }
+}
+
+class DataImportException implements Exception {
+  final String message;
+  const DataImportException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/services/hive_service.dart
+++ b/lib/core/services/hive_service.dart
@@ -12,6 +12,17 @@ class HiveService {
   static const String medicationLogsBoxName = 'medicationLogs';
   static const String treatmentsBoxName = 'treatments';
   static const String pillboxBoxName = 'pillboxData';
+
+  /// Boxes that participate in user-data export/import.
+  /// Excludes device-specific boxes (medication_scheduler, medication_actions, disclaimer_box).
+  static const List<String> exportableBoxNames = [
+    userPrefsBox,
+    moodBoxName,
+    symptomBoxName,
+    medicationLogsBoxName,
+    treatmentsBoxName,
+    pillboxBoxName,
+  ];
   static const String lastMoodDateKey = 'lastMoodDate';
   static const String userMoodKey = 'userMood';
   static const String userMoodDescriptionKey = 'userMoodDescription';
@@ -769,6 +780,48 @@ class HiveService {
       return data;
     }
     return [];
+  }
+
+  /// Read every entry from each exportable box into a plain JSON-safe map.
+  /// Top-level shape: `{ boxName: { key: value, ... }, ... }`.
+  /// Keys and nested maps are normalized to `Map<String, dynamic>` so the
+  /// result round-trips cleanly through `jsonEncode`/`jsonDecode`.
+  static Future<Map<String, Map<String, dynamic>>> exportAllBoxes() async {
+    final result = <String, Map<String, dynamic>>{};
+    for (final boxName in exportableBoxNames) {
+      final box = await _openBox(boxName);
+      final boxMap = <String, dynamic>{};
+      for (final key in box.keys) {
+        final value = box.get(key);
+        boxMap[key.toString()] = _sanitizeValue(value);
+      }
+      result[boxName] = boxMap;
+    }
+    return result;
+  }
+
+  /// Replace the contents of every exportable box with the supplied data.
+  /// Each box is cleared then re-populated. Box keys missing from `data` are
+  /// cleared (so a partial import does not leave stale entries). Unknown box
+  /// names in `data` are ignored.
+  static Future<void> importAllBoxes(Map<String, dynamic> data) async {
+    for (final boxName in exportableBoxNames) {
+      final box = await _openBox(boxName);
+      await box.clear();
+      final raw = data[boxName];
+      if (raw is! Map) continue;
+      for (final entry in raw.entries) {
+        await box.put(entry.key.toString(), _sanitizeValue(entry.value));
+      }
+    }
+  }
+
+  /// Recursively normalize a Hive/JSON value so all maps are `Map<String, dynamic>`.
+  /// Mirrors `_sanitizeMap`/`_sanitizeList` but also handles top-level scalars.
+  static dynamic _sanitizeValue(dynamic value) {
+    if (value is Map) return _sanitizeMap(value);
+    if (value is List) return _sanitizeList(value);
+    return value;
   }
 
   /// Delete all user data from the device

--- a/lib/features/profile/presentation/profile.dart
+++ b/lib/features/profile/presentation/profile.dart
@@ -2,6 +2,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pinkrain/core/widgets/bottom_navigation.dart';
 import 'package:pinkrain/core/widgets/components.dart';
@@ -14,6 +15,9 @@ import 'package:pinkrain/core/services/data_transfer_service.dart';
 import 'package:pinkrain/core/services/hive_service.dart';
 import 'package:pinkrain/core/theme/tokens.dart';
 import 'package:pinkrain/core/theme/colors.dart';
+import 'package:pinkrain/features/journal/presentation/journal_medication_notifier.dart';
+import 'package:pinkrain/features/journal/presentation/journal_notifier.dart';
+import 'package:pinkrain/features/pillbox/presentation/pillbox_notifier.dart';
 import 'package:pinkrain/features/treatment/services/medication_notification_service.dart';
 import 'package:pinkrain/features/treatment/services/medication_scheduler_service.dart';
 import 'package:pinkrain/core/services/disclaimer_service.dart';
@@ -23,14 +27,14 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'dart:io';
 
 
-class ProfileScreen extends StatefulWidget {
+class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
 
   @override
   ProfileScreenState createState() => ProfileScreenState();
 }
 
-class ProfileScreenState extends State<ProfileScreen> {
+class ProfileScreenState extends ConsumerState<ProfileScreen> {
   bool isReminderEnabled = true;
   bool isFillUpPillboxEnabled = false;
   late TextEditingController _nameController;
@@ -1026,6 +1030,16 @@ class ProfileScreenState extends State<ProfileScreen> {
 
     if (mounted) hostNavigatorState.pop();
     if (!mounted) return;
+
+    // Throw away every notifier whose state was populated from Hive before
+    // the import. Riverpod will rebuild them on next read, picking up the
+    // freshly imported data. Without this, the in-memory state is stale and
+    // — worse — the next pillbox/journal mutation would write the pre-import
+    // state back over the imported Hive contents.
+    ref.invalidate(pillBoxProvider);
+    ref.invalidate(pillIntakeProvider);
+    ref.invalidate(journalMedicationNotifierProvider);
+    ref.invalidate(selectedDateProvider);
 
     showCupertinoDialog(
       context: context,

--- a/lib/features/profile/presentation/profile.dart
+++ b/lib/features/profile/presentation/profile.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +10,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pinkrain/core/util/helpers.dart' show devPrint;
+import 'package:pinkrain/core/services/data_transfer_service.dart';
 import 'package:pinkrain/core/services/hive_service.dart';
 import 'package:pinkrain/core/theme/tokens.dart';
 import 'package:pinkrain/core/theme/colors.dart';
@@ -392,6 +394,28 @@ class ProfileScreenState extends State<ProfileScreen> {
                   color: AppTokens.iconPrimary,
                 ),
               ),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text('Export Data', style: AppTokens.textStyleMedium),
+                trailing: HugeIcon(
+                  icon: HugeIcons.strokeRoundedDownload01,
+                  size: 24,
+                  strokeWidth: 1,
+                  color: AppTokens.iconPrimary,
+                ),
+                onTap: _showExportConfirmationModal,
+              ),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text('Import Data', style: AppTokens.textStyleMedium),
+                trailing: HugeIcon(
+                  icon: HugeIcons.strokeRoundedUpload01,
+                  size: 24,
+                  strokeWidth: 1,
+                  color: AppTokens.iconPrimary,
+                ),
+                onTap: _pickAndImportData,
+              ),
               _buildHelpTile('Delete All Data'),
               SizedBox(height: 30),
               Center(
@@ -637,6 +661,391 @@ class ProfileScreenState extends State<ProfileScreen> {
           ),
         );
       },
+    );
+  }
+
+  // Bottom-sheet confirmation for exporting all data as JSON.
+  void _showExportConfirmationModal() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (BuildContext sheetContext) {
+        return Container(
+          decoration: const BoxDecoration(
+            color: AppTokens.bgPrimary,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      margin: const EdgeInsets.only(bottom: 20),
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: AppTokens.borderLight,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  Text(
+                    'Export Data',
+                    style: AppTokens.textStyleXLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'A JSON file will be created with all your data, including:\n'
+                    '• Mood entries\n'
+                    '• Symptom data\n'
+                    '• Medication logs\n'
+                    '• Treatments\n'
+                    '• Pillbox data\n'
+                    '• User preferences\n\n'
+                    'You will be able to share or save the file using your device\'s share sheet. '
+                    'Keep it private — it contains your personal health data.',
+                    style: AppTokens.textStyleMedium.copyWith(
+                      color: AppTokens.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Button.primary(
+                      onPressed: () {
+                        Navigator.of(sheetContext).pop();
+                        _runExport();
+                      },
+                      text: 'Export Data',
+                      size: ButtonSize.large,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Button.secondary(
+                      onPressed: () => Navigator.of(sheetContext).pop(),
+                      text: 'Cancel',
+                      size: ButtonSize.large,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // Produce the JSON file and hand it to the share sheet.
+  Future<void> _runExport() async {
+    if (!mounted) return;
+    final hostContext = context;
+    final hostNavigatorState = Navigator.of(hostContext);
+
+    showCupertinoDialog(
+      context: hostContext,
+      barrierDismissible: false,
+      builder: (context) => const CupertinoAlertDialog(
+        content: Padding(
+          padding: EdgeInsets.only(top: 20.0),
+          child: CupertinoActivityIndicator(),
+        ),
+      ),
+    );
+
+    String? exportPath;
+    try {
+      exportPath = await DataTransferService.exportToFile();
+    } catch (e) {
+      devPrint('❌ Export failed: $e');
+      if (mounted) hostNavigatorState.pop();
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Export Failed'),
+            content: Text('Could not produce export file: $e'),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
+    if (mounted) hostNavigatorState.pop();
+    if (!mounted) return;
+
+    try {
+      await SharePlus.instance.share(ShareParams(
+        files: [XFile(exportPath)],
+        subject: 'PinkRain Data Export',
+        text: 'PinkRain data export — keep this file private.',
+      ));
+    } catch (e) {
+      devPrint('❌ Share failed: $e');
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Could Not Share'),
+            content: Text(
+              'Export saved to:\n$exportPath\n\nBut sharing failed: $e',
+            ),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+    }
+  }
+
+  // Open the native file picker for a .json file, then show the import
+  // confirmation modal if the user picked something.
+  Future<void> _pickAndImportData() async {
+    FilePickerResult? result;
+    try {
+      result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+    } catch (e) {
+      devPrint('❌ File picker failed: $e');
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Could Not Open File Picker'),
+            content: Text('$e'),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
+    if (result == null || result.files.isEmpty) return;
+    final picked = result.files.single;
+    final path = picked.path;
+    if (path == null) {
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Could Not Read File'),
+            content: const Text('Please pick the file from a different location.'),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
+    if (!mounted) return;
+    _showImportConfirmationModal(path, picked.name);
+  }
+
+  // Bottom-sheet confirmation for replacing all data with an import file.
+  void _showImportConfirmationModal(String path, String fileName) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (BuildContext sheetContext) {
+        return Container(
+          decoration: const BoxDecoration(
+            color: AppTokens.bgPrimary,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      margin: const EdgeInsets.only(bottom: 20),
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: AppTokens.borderLight,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  Text(
+                    'Replace All Data?',
+                    style: AppTokens.textStyleXLarge.copyWith(
+                      color: AppTokens.stateError,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'This will permanently replace all data on this device with the contents of:\n\n'
+                    '$fileName\n\n'
+                    'This action cannot be undone.',
+                    style: AppTokens.textStyleMedium.copyWith(
+                      color: AppTokens.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Button.destructive(
+                      onPressed: () {
+                        Navigator.of(sheetContext).pop();
+                        _runImport(path);
+                      },
+                      text: 'Replace All Data',
+                      size: ButtonSize.large,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Button.secondary(
+                      onPressed: () => Navigator.of(sheetContext).pop(),
+                      text: 'Cancel',
+                      size: ButtonSize.large,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // Apply the import file and navigate to a fresh wellness screen on success.
+  Future<void> _runImport(String path) async {
+    if (!mounted) return;
+    final hostContext = context;
+    final hostNavigatorState = Navigator.of(hostContext);
+
+    showCupertinoDialog(
+      context: hostContext,
+      barrierDismissible: false,
+      builder: (context) => const CupertinoAlertDialog(
+        content: Padding(
+          padding: EdgeInsets.only(top: 20.0),
+          child: CupertinoActivityIndicator(),
+        ),
+      ),
+    );
+
+    try {
+      await DataTransferService.importFromFile(path);
+      // Refresh in-screen name controller so it reflects the imported value.
+      final importedName = await HiveService.getUserName();
+      if (mounted) {
+        _nameController.text = importedName;
+      }
+    } on DataImportException catch (e) {
+      devPrint('❌ Import rejected: ${e.message}');
+      if (mounted) hostNavigatorState.pop();
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Import Failed'),
+            content: Text(e.message),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    } catch (e) {
+      devPrint('❌ Import failed mid-flight: $e');
+      if (mounted) hostNavigatorState.pop();
+      if (mounted) {
+        showCupertinoDialog(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: const Text('Import Failed'),
+            content: Text(
+              'Something went wrong while restoring data:\n$e\n\n'
+              'Some data may have been partially imported. Run import again to retry.',
+            ),
+            actions: [
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
+    if (mounted) hostNavigatorState.pop();
+    if (!mounted) return;
+
+    showCupertinoDialog(
+      context: context,
+      builder: (context) => CupertinoAlertDialog(
+        title: const Text('Data Imported'),
+        content: const Text(
+          'Your data has been restored. The app will now refresh.',
+        ),
+        actions: [
+          CupertinoDialogAction(
+            isDefaultAction: true,
+            onPressed: () {
+              Navigator.of(context).pop();
+              if (!mounted) return;
+              this.context.go('/wellness');
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      ),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -323,6 +331,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   hugeicons: ^1.1.6
   hux: ^0.25.0
   package_info_plus: ^8.0.0
+  file_picker: ^8.1.4
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:pinkrain/core/services/data_transfer_service.dart';
 import 'package:pinkrain/core/services/hive_service.dart';
 
 void main() {
@@ -193,6 +194,172 @@ void main() {
       expect(Hive.box(name).isEmpty, isTrue,
           reason: '$name should have been cleared by an empty import.');
     }
+  });
+
+  // ---- validateEnvelope ----
+  //
+  // These guard the destructive write path. Anything that would later make
+  // Treatment.fromJson or MedicineInventorySerialization.fromJson fall back
+  // to a placeholder object (silently replacing real user data) must be
+  // rejected here, BEFORE importFromFile touches Hive.
+
+  Map<String, dynamic> validTreatmentEntry() => {
+        'id': '1747000000000123456',
+        'medicine': {
+          'name': 'Paracetamol',
+          'type': 'Pain Killer',
+          'color': 'White',
+          'specification': {
+            'dosage': 20.0,
+            'unit': 'mg',
+            'useCase': '',
+          },
+        },
+        'treatmentPlan': {
+          'startDate': '2026-05-10T00:00:00.000Z',
+          'endDate': '2026-06-10T00:00:00.000Z',
+          'timeOfDay': '1970-01-01T09:00:00.000Z',
+          'mealOption': '',
+          'instructions': '',
+          'frequency': 1,
+        },
+        'notes': '',
+      };
+
+  Map<String, dynamic> envelopeWith(
+      {List<Map<String, dynamic>>? treatments,
+      List<Map<String, dynamic>>? pillbox}) {
+    final boxes = <String, dynamic>{};
+    if (treatments != null) {
+      boxes[HiveService.treatmentsBoxName] = {'treatments': treatments};
+    }
+    if (pillbox != null) {
+      boxes[HiveService.pillboxBoxName] = {'pillbox': pillbox};
+    }
+    return {
+      'schema': DataTransferService.schemaTag,
+      'version': DataTransferService.schemaVersion,
+      'boxes': boxes,
+    };
+  }
+
+  test('validateEnvelope accepts a well-formed envelope', () {
+    expect(
+      () => DataTransferService.validateEnvelope(
+          envelopeWith(treatments: [validTreatmentEntry()])),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope rejects wrong schema tag', () {
+    final env = envelopeWith()..['schema'] = 'something-else';
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects wrong version', () {
+    final env = envelopeWith()..['version'] = 99;
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects empty medicine object (the regression case)',
+      () {
+    // This is the exact shape the reviewer flagged: schema/version OK,
+    // medicine + treatmentPlan present but empty. Old code accepted this
+    // and then Treatment.fromJson would silently produce an "Error Treatment".
+    final bad = {
+      'id': 'x',
+      'medicine': <String, dynamic>{},
+      'treatmentPlan': <String, dynamic>{},
+      'notes': '',
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects unparseable startDate', () {
+    final bad = validTreatmentEntry()
+      ..['treatmentPlan'] = {
+        ...(validTreatmentEntry()['treatmentPlan'] as Map<String, dynamic>),
+        'startDate': 'not-a-date',
+      };
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects dosage of the wrong type', () {
+    final bad = validTreatmentEntry();
+    (bad['medicine'] as Map<String, dynamic>)['specification'] = {
+      'dosage': '20', // string instead of num — fromJson would crash
+      'unit': 'mg',
+      'useCase': '',
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects missing notes field', () {
+    // Treatment.fromJson does `json['notes'] as String` which throws on null.
+    final bad = validTreatmentEntry()..remove('notes');
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects pillbox entry missing medicine.specs', () {
+    final bad = {
+      'medicine': {
+        'name': 'Aspirin',
+        'type': 'Tablet',
+        'color': 'White',
+        // 'specs' missing
+      },
+      'quantity': 30,
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(pillbox: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('importFromFile leaves Hive untouched when validation fails', () async {
+    await seedFixtureData();
+    final before = jsonEncode(snapshotBoxes());
+
+    // Craft a malformed export and write it to disk.
+    final badEnvelope = envelopeWith(treatments: [
+      {
+        'id': 'x',
+        'medicine': <String, dynamic>{},
+        'treatmentPlan': <String, dynamic>{},
+        'notes': '',
+      }
+    ]);
+    final badFile = File('${tempDir.path}/bad_import.json');
+    await badFile.writeAsString(jsonEncode(badEnvelope));
+
+    expect(
+      () => DataTransferService.importFromFile(badFile.path),
+      throwsA(isA<DataImportException>()),
+    );
+
+    // The seeded data must still be there byte-for-byte. This is the actual
+    // safety property the reviewer wanted: a malformed file does not cost the
+    // user their local data.
+    final after = jsonEncode(snapshotBoxes());
+    expect(after, equals(before));
   });
 
   test('exportAllBoxes returns Map<String, dynamic> for all nested maps', () async {

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -375,6 +375,180 @@ void main() {
     );
   });
 
+  // ---- per-box content validation for the four "other" boxes ----
+
+  test('validateEnvelope rejects userPreferences.userMood with wrong type', () {
+    // getUserMood returns Future<int>; await would TypeError on a string.
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.userPrefsBox] = {
+      'userMood': '4', // string instead of int
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects userPreferences.userName with wrong type', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.userPrefsBox] = {
+      'userName': 42,
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope accepts userPreferences with unknown keys (forward compat)',
+      () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.userPrefsBox] = {
+      'userMood': 3,
+      'userName': 'Alice',
+      'someFutureField': {'arbitrary': true},
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope rejects mood entry with non-int mood value', () {
+    // Direct regression for wellness_screen.dart:201 (`mood as int`).
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.moodBoxName] = {
+      'mood_2026-05-18': [
+        {
+          'mood': 'three',
+          'description': 'oops',
+          'timestamp': '2026-05-18T09:00:00.000Z',
+        },
+      ],
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope accepts the legacy single-map mood entry shape', () {
+    // getMoodEntriesForDate handles both List-of-entries and a single Map
+    // for legacy data. Validation must accept both, otherwise we'd reject
+    // exports from older app installs.
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.moodBoxName] = {
+      'mood_2026-05-18': {
+        'mood': 3,
+        'description': 'legacy entry',
+        'timestamp': '2026-05-18T09:00:00.000Z',
+      },
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope rejects mood entry with unparseable timestamp', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.moodBoxName] = {
+      'mood_2026-05-18': [
+        {
+          'mood': 3,
+          'description': '',
+          'timestamp': 'yesterday-ish',
+        },
+      ],
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects symptom entry whose symptoms is not a list',
+      () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.symptomBoxName] = {
+      '2026-05-18': {
+        'date': '2026-05-18',
+        'symptoms': 'headache', // should be a list
+      },
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects symptom list with non-string entries', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.symptomBoxName] = {
+      '2026-05-18': {
+        'date': '2026-05-18',
+        'symptoms': ['headache', 42],
+      },
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medicationLogs value that is not a list', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.medicationLogsBoxName] =
+        {
+      'logs_2026-05-18': {'not': 'a list'},
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medicationLogs entry that is not a map', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.medicationLogsBoxName] =
+        {
+      'logs_2026-05-18': ['scalar-instead-of-map'],
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('importFromFile leaves Hive untouched when moodData is malformed',
+      () async {
+    // Integration check: a bad mood value (the wellness-crash scenario)
+    // must be rejected before any destructive op runs.
+    await seedFixtureData();
+    final before = jsonEncode(snapshotBoxes());
+
+    final badEnvelope = envelopeWith();
+    (badEnvelope['boxes'] as Map<String, dynamic>)[HiveService.moodBoxName] = {
+      'mood_2026-05-18': [
+        {
+          'mood': 'high',
+          'description': '',
+          'timestamp': '2026-05-18T09:00:00.000Z',
+        },
+      ],
+    };
+    final badFile = File('${tempDir.path}/bad_mood.json');
+    await badFile.writeAsString(jsonEncode(badEnvelope));
+
+    expect(
+      () => DataTransferService.importFromFile(badFile.path),
+      throwsA(isA<DataImportException>()),
+    );
+
+    final after = jsonEncode(snapshotBoxes());
+    expect(after, equals(before));
+  });
+
   test('importFromFile leaves Hive untouched when a box wrapper is missing',
       () async {
     // Integration check of the missing-box rejection: a corrupted export

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -229,7 +229,13 @@ void main() {
   Map<String, dynamic> envelopeWith(
       {List<Map<String, dynamic>>? treatments,
       List<Map<String, dynamic>>? pillbox}) {
-    final boxes = <String, dynamic>{};
+    // Mirror what HiveService.exportAllBoxes produces: every exportable box
+    // wrapper is present, empty by default. Tests can override the
+    // treatments / pillbox slots with their own fixtures.
+    final boxes = <String, dynamic>{
+      for (final name in HiveService.exportableBoxNames)
+        name: <String, dynamic>{},
+    };
     if (treatments != null) {
       boxes[HiveService.treatmentsBoxName] = {'treatments': treatments};
     }
@@ -340,21 +346,55 @@ void main() {
     );
   });
 
-  test('validateEnvelope accepts a missing box (treated as empty)', () {
-    // A box missing from the envelope is a valid migration: the source
-    // device had no data for it, so the destination should also be empty.
-    // We rely on HiveService.importAllBoxes to clear local state.
+  test('validateEnvelope rejects a missing exportable box', () {
+    // HiveService.exportAllBoxes always writes all six box wrappers (even
+    // empty as {}). A missing key means the file was truncated or
+    // hand-edited — accepting it would let HiveService.importAllBoxes
+    // clear the local box and skip repopulation, silently wiping user data.
     final env = envelopeWith(treatments: [validTreatmentEntry()]);
-    expect(
-      (env['boxes'] as Map<String, dynamic>)
-          .containsKey(HiveService.pillboxBoxName),
-      isFalse,
-      reason: 'sanity: pillbox is intentionally absent from this fixture',
-    );
+    (env['boxes'] as Map<String, dynamic>).remove(HiveService.pillboxBoxName);
     expect(
       () => DataTransferService.validateEnvelope(env),
-      returnsNormally,
+      throwsA(isA<DataImportException>()),
     );
+  });
+
+  test('validateEnvelope rejects selectedDays with wrong length', () {
+    // TreatmentPlan.shouldTakeOnDate indexes selectedDays by weekday 0..6
+    // (treatment.dart:82). A shorter list throws RangeError post-import,
+    // after the user has already lost their original data.
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['selectedDays'] = [
+      true,
+      true,
+      true,
+    ];
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('importFromFile leaves Hive untouched when a box wrapper is missing',
+      () async {
+    // Integration check of the missing-box rejection: a corrupted export
+    // with a missing wrapper must fail before any destructive op runs.
+    await seedFixtureData();
+    final before = jsonEncode(snapshotBoxes());
+
+    final badEnvelope = envelopeWith();
+    (badEnvelope['boxes'] as Map<String, dynamic>)
+        .remove(HiveService.treatmentsBoxName);
+    final badFile = File('${tempDir.path}/missing_box.json');
+    await badFile.writeAsString(jsonEncode(badEnvelope));
+
+    expect(
+      () => DataTransferService.importFromFile(badFile.path),
+      throwsA(isA<DataImportException>()),
+    );
+
+    final after = jsonEncode(snapshotBoxes());
+    expect(after, equals(before));
   });
 
   test('validateEnvelope rejects selectedDays with non-boolean entries', () {

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -520,6 +520,127 @@ void main() {
     );
   });
 
+  test('validateEnvelope rejects symptom entry whose date is unparseable', () {
+    // getSymptomEntries does DateTime.parse inside a loop wrapped in
+    // try/catch that returns []. So one bad date silently nukes ALL
+    // symptom data on every read, not just the bad entry.
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.symptomBoxName] = {
+      '2026-05-18': {
+        'date': 'yesterday-ish', // string, but not parseable
+        'symptoms': ['headache'],
+      },
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  // ---- medication log row validation ----
+  //
+  // IntakeLog.fromMap is defensive: missing/wrong-typed fields silently
+  // become "Unknown Medicine" / dosage 1.0 / DateTime.now() placeholders.
+  // That's exactly the silent-corruption mode we cannot accept after a
+  // destructive import. Validate every field the writer produces.
+
+  Map<String, dynamic> validMedLogRow() => {
+        'treatment_id': '1747000000000123456',
+        'medicine_name': 'Paracetamol',
+        'medicine_type': 'Pain Killer',
+        'medicine_color': 'White',
+        'dosage': 20.0,
+        'unit': 'mg',
+        'treatment_plan_start_date': '2026-05-10T00:00:00.000Z',
+        'treatment_plan_end_date': '2026-06-10T00:00:00.000Z',
+        'dose_time': '2026-05-18T09:00:00.000Z',
+        'is_taken': true,
+        'is_skipped': false,
+      };
+
+  Map<String, dynamic> envelopeWithMedLog(Map<String, dynamic> row) {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.medicationLogsBoxName] =
+        {
+      'logs_2026-05-18': [row],
+    };
+    return env;
+  }
+
+  test('validateEnvelope accepts well-formed medication log rows', () {
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(validMedLogRow())),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope accepts a medication log row without dose_time', () {
+    // dose_time is the only field allowed to be missing (legacy single-dose
+    // treatments from older app versions).
+    final row = validMedLogRow()..remove('dose_time');
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope accepts a medication log row with null dose_time', () {
+    final row = validMedLogRow()..['dose_time'] = null;
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope rejects medication log row with non-string medicine_name',
+      () {
+    // fromMap would substitute "Unknown Medicine" silently.
+    final row = validMedLogRow()..['medicine_name'] = 42;
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medication log row with non-numeric dosage', () {
+    // fromMap would substitute 1.0 silently.
+    final row = validMedLogRow()..['dosage'] = 'ten mg';
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medication log row with unparseable date', () {
+    // fromMap would substitute DateTime.now() silently.
+    final row = validMedLogRow()
+      ..['treatment_plan_start_date'] = 'not-a-date';
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medication log row with non-boolean is_taken',
+      () {
+    // fromMap tolerates int/string representations of bool and silently
+    // coerces. Strict here so we don't accept truthy-ish corruption.
+    final row = validMedLogRow()..['is_taken'] = 1;
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects medication log row with unparseable dose_time',
+      () {
+    final row = validMedLogRow()..['dose_time'] = 'whenever';
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWithMedLog(row)),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
   test('importFromFile leaves Hive untouched when moodData is malformed',
       () async {
     // Integration check: a bad mood value (the wellness-crash scenario)

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -318,6 +318,137 @@ void main() {
     );
   });
 
+  test('validateEnvelope rejects boxes wrapper of wrong type (list)', () {
+    // P2-2 regression: "treatments": [] silently passed before, and
+    // importAllBoxes would clear the local box and skip repopulation.
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.treatmentsBoxName] =
+        <dynamic>[];
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects boxes wrapper of wrong type (string)', () {
+    final env = envelopeWith();
+    (env['boxes'] as Map<String, dynamic>)[HiveService.pillboxBoxName] =
+        'oops';
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope accepts a missing box (treated as empty)', () {
+    // A box missing from the envelope is a valid migration: the source
+    // device had no data for it, so the destination should also be empty.
+    // We rely on HiveService.importAllBoxes to clear local state.
+    final env = envelopeWith(treatments: [validTreatmentEntry()]);
+    expect(
+      (env['boxes'] as Map<String, dynamic>)
+          .containsKey(HiveService.pillboxBoxName),
+      isFalse,
+      reason: 'sanity: pillbox is intentionally absent from this fixture',
+    );
+    expect(
+      () => DataTransferService.validateEnvelope(env),
+      returnsNormally,
+    );
+  });
+
+  test('validateEnvelope rejects selectedDays with non-boolean entries', () {
+    // P2-1: Treatment.fromJson does `(e as bool)` and would crash → silent
+    // "Error Treatment" fallback if we didn't reject this up front.
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['selectedDays'] = [
+      true,
+      'bad',
+      true,
+    ];
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects selectedDays of the wrong shape', () {
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['selectedDays'] = 'not-a-list';
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects unparseable doseTimes entry', () {
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['doseTimes'] = [
+      '1970-01-01T09:00:00.000Z',
+      'not-a-date',
+    ];
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects doseNamesMap with unparseable values', () {
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['doseNamesMap'] = {
+      'Morning': 'not-a-date',
+    };
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope rejects doseNamesMap of the wrong shape', () {
+    final bad = validTreatmentEntry();
+    (bad['treatmentPlan'] as Map<String, dynamic>)['doseNamesMap'] = ['Morning'];
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [bad])),
+      throwsA(isA<DataImportException>()),
+    );
+  });
+
+  test('validateEnvelope accepts treatments with valid optional fields', () {
+    // Sanity: the optional-field validation must not reject well-formed
+    // exports (the round-trip test seeds doseTimes and doseNamesMap).
+    final good = validTreatmentEntry();
+    (good['treatmentPlan'] as Map<String, dynamic>)
+      ..['doseTimes'] = ['1970-01-01T09:00:00.000Z']
+      ..['doseNamesMap'] = {'Morning': '1970-01-01T09:00:00.000Z'}
+      ..['selectedDays'] = [true, true, true, true, true, false, false];
+    expect(
+      () => DataTransferService.validateEnvelope(envelopeWith(treatments: [good])),
+      returnsNormally,
+    );
+  });
+
+  test('importFromFile leaves Hive untouched when boxes wrapper is wrong type',
+      () async {
+    // The P2-2 regression scenario as an integration test: present-but-not-a-map
+    // box must be rejected BEFORE HiveService.importAllBoxes clears anything.
+    await seedFixtureData();
+    final before = jsonEncode(snapshotBoxes());
+
+    final badEnvelope = envelopeWith();
+    (badEnvelope['boxes'] as Map<String, dynamic>)[
+        HiveService.treatmentsBoxName] = <dynamic>[];
+    final badFile = File('${tempDir.path}/bad_wrapper.json');
+    await badFile.writeAsString(jsonEncode(badEnvelope));
+
+    expect(
+      () => DataTransferService.importFromFile(badFile.path),
+      throwsA(isA<DataImportException>()),
+    );
+
+    final after = jsonEncode(snapshotBoxes());
+    expect(after, equals(before));
+  });
+
   test('validateEnvelope rejects pillbox entry missing medicine.specs', () {
     final bad = {
       'medicine': {

--- a/test/unit/data_transfer_service_test.dart
+++ b/test/unit/data_transfer_service_test.dart
@@ -1,0 +1,226 @@
+// Round-trip test for the JSON export/import pipeline.
+//
+// We seed each of the six exportable Hive boxes with one representative
+// entry whose shape mirrors what the existing writers produce
+// (Treatment.toJson, MedicineInventorySerialization.toJson, IntakeLog.toMap,
+// HiveService.saveSymptom, HiveService.saveMoodForDate, user prefs).
+// Then we call HiveService.exportAllBoxes -> jsonEncode -> jsonDecode ->
+// HiveService.importAllBoxes and assert every box's contents are unchanged.
+//
+// This is the cheapest single check that would catch a regression where a
+// field name in one of the existing toJson methods drifts from what the
+// matching fromJson reader expects.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:pinkrain/core/services/hive_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('test_hive_export_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    // Wipe between tests so each one starts from a known empty state.
+    for (final name in HiveService.exportableBoxNames) {
+      final box = await Hive.openBox(name);
+      await box.clear();
+    }
+  });
+
+  Future<void> seedFixtureData() async {
+    // 1. userPreferences — flat key/value box.
+    final prefs = await Hive.openBox(HiveService.userPrefsBox);
+    await prefs.put('userName', 'Alice');
+    await prefs.put('userMood', 4);
+    await prefs.put('userMoodDescription', 'Good day');
+    await prefs.put('lastMoodDate', '2026-05-19T09:00:00.000Z');
+
+    // 2. moodData — list-of-entries keyed by mood_<date>.
+    final mood = await Hive.openBox(HiveService.moodBoxName);
+    await mood.put('mood_2026-05-18', [
+      {
+        'mood': 3,
+        'description': 'Tired',
+        'timestamp': '2026-05-18T20:30:00.000Z',
+      },
+    ]);
+
+    // 3. symptomData — keyed by yyyy-MM-dd, value carries `date` + `symptoms`.
+    final symptoms = await Hive.openBox(HiveService.symptomBoxName);
+    await symptoms.put('2026-05-18', {
+      'date': '2026-05-18',
+      'symptoms': ['headache', 'fatigue'],
+    });
+
+    // 4. medicationLogs — keyed by logs_<date>, value is a list of IntakeLog.toMap().
+    final medLogs = await Hive.openBox(HiveService.medicationLogsBoxName);
+    await medLogs.put('logs_2026-05-18', [
+      {
+        'treatment_id': '1747000000000123456',
+        'medicine_name': 'Paracetamol',
+        'medicine_type': 'Pain Killer',
+        'medicine_color': 'White',
+        'dosage': 20.0,
+        'unit': 'mg',
+        'treatment_plan_start_date': '2026-05-10T00:00:00.000Z',
+        'treatment_plan_end_date': '2026-06-10T00:00:00.000Z',
+        'dose_time': '2026-05-18T09:00:00.000Z',
+        'is_taken': true,
+        'is_skipped': false,
+      },
+    ]);
+
+    // 5. treatments — single key 'treatments' wrapping a list of Treatment.toJson().
+    //    NOTE: this uses key 'specification' (not 'specs'), matching Treatment.toJson.
+    final treatments = await Hive.openBox(HiveService.treatmentsBoxName);
+    await treatments.put('treatments', [
+      {
+        'id': '1747000000000123456',
+        'medicine': {
+          'name': 'Paracetamol',
+          'type': 'Pain Killer',
+          'color': 'White',
+          'specification': {
+            'dosage': 20.0,
+            'unit': 'mg',
+            'useCase': 'For headaches',
+          },
+        },
+        'treatmentPlan': {
+          'startDate': '2026-05-10T00:00:00.000Z',
+          'endDate': '2026-06-10T00:00:00.000Z',
+          'timeOfDay': '1970-01-01T09:00:00.000Z',
+          'doseTimes': <String>['1970-01-01T09:00:00.000Z'],
+          'doseNamesMap': <String, String>{
+            'Morning': '1970-01-01T09:00:00.000Z',
+          },
+          'mealOption': 'After meals',
+          'instructions': 'Take with water',
+          'frequency': 1,
+          'selectedDays': [true, true, true, true, true, true, true],
+        },
+        'notes': 'Doctor recommended',
+      },
+    ]);
+
+    // 6. pillboxData — single key 'pillbox' wrapping a list of MedicineInventorySerialization.toJson().
+    //    NOTE: this uses key 'specs' (not 'specification') — the divergence is intentional.
+    final pillbox = await Hive.openBox(HiveService.pillboxBoxName);
+    await pillbox.put('pillbox', [
+      {
+        'medicine': {
+          'name': 'Paracetamol',
+          'type': 'Pain Killer',
+          'color': 'White',
+          'specs': {
+            'dosage': 20.0,
+            'unit': 'mg',
+            'useCase': '',
+          },
+        },
+        'quantity': 180,
+      },
+    ]);
+  }
+
+  Map<String, Map<String, dynamic>> snapshotBoxes() {
+    final result = <String, Map<String, dynamic>>{};
+    for (final name in HiveService.exportableBoxNames) {
+      final box = Hive.box(name);
+      final boxMap = <String, dynamic>{};
+      for (final key in box.keys) {
+        boxMap[key.toString()] = box.get(key);
+      }
+      result[name] = boxMap;
+    }
+    return result;
+  }
+
+  test('export then import round-trips all six boxes byte-for-byte', () async {
+    await seedFixtureData();
+
+    // 1. Export.
+    final exported = await HiveService.exportAllBoxes();
+
+    // 2. Run through the JSON pipeline that DataTransferService uses on disk.
+    final encoded = jsonEncode(exported);
+    final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+
+    // 3. Wipe everything, then import.
+    for (final name in HiveService.exportableBoxNames) {
+      await Hive.box(name).clear();
+    }
+    await HiveService.importAllBoxes(decoded);
+
+    // 4. Read everything back and compare against the JSON-shape baseline.
+    //    We compare against the encoded JSON (not the raw seeded values),
+    //    because Hive may normalize types (int vs double) and we want the
+    //    round-trip to be idempotent at the JSON level — that's the
+    //    contract DataTransferService actually relies on.
+    final after = snapshotBoxes();
+    final afterJson = jsonDecode(jsonEncode(after)) as Map<String, dynamic>;
+
+    for (final name in HiveService.exportableBoxNames) {
+      expect(afterJson[name], equals(decoded[name]),
+          reason: 'Box "$name" did not survive the export/import round-trip.');
+    }
+  });
+
+  test('importAllBoxes wipes existing entries even when input is empty', () async {
+    await seedFixtureData();
+    // Sanity check: data is in place.
+    expect(Hive.box(HiveService.treatmentsBoxName).get('treatments'), isNotNull);
+
+    await HiveService.importAllBoxes(const <String, dynamic>{});
+
+    for (final name in HiveService.exportableBoxNames) {
+      expect(Hive.box(name).isEmpty, isTrue,
+          reason: '$name should have been cleared by an empty import.');
+    }
+  });
+
+  test('exportAllBoxes returns Map<String, dynamic> for all nested maps', () async {
+    await seedFixtureData();
+    final exported = await HiveService.exportAllBoxes();
+
+    // The contract of HiveService.exportAllBoxes is that every nested map is a
+    // Map<String, dynamic> — not Map<dynamic, dynamic> — so that jsonEncode
+    // works without throwing and so that downstream readers' casts succeed.
+    void assertStringKeyedRecursively(dynamic node) {
+      if (node is Map) {
+        expect(node, isA<Map<String, dynamic>>(),
+            reason: 'Found a non-String-keyed map in the export.');
+        for (final value in node.values) {
+          assertStringKeyedRecursively(value);
+        }
+      } else if (node is List) {
+        for (final item in node) {
+          assertStringKeyedRecursively(item);
+        }
+      }
+    }
+
+    for (final box in exported.values) {
+      assertStringKeyedRecursively(box);
+    }
+
+    // Final smoke: the JSON encoder must accept the output as-is.
+    expect(() => jsonEncode(exported), returnsNormally);
+  });
+}


### PR DESCRIPTION
Adds Profile → Export Data / Import Data so users can move all six user-data Hive boxes (userPreferences, moodData, symptomData, medicationLogs, treatments, pillboxData) between devices via a single JSON file. Export uses share_plus; import uses file_picker with a destructive confirmation modal mirroring the existing Delete All Data flow. Device-specific boxes (medication_scheduler, medication_actions) are wiped on import and rebuilt from the imported treatments by re-running the startup notification scheduling. Schema is versioned (version: 1) so future shape changes can be gated.

Includes a roundtrip unit test that seeds every box with fixture data matching the existing toJson shapes, runs it through jsonEncode/jsonDecode, and asserts byte-for-byte equality on import — the cheapest single check that catches a regression where a writer's field name drifts from the matching reader's expectation.

Known limitation: Riverpod notifiers (PillBoxNotifier, PillIntakeNotifier) cache state in memory and won't refresh after import until the app is restarted. Same bug exists in the existing Delete All Data flow. Follow-up will convert ProfileScreen to ConsumerStatefulWidget and invalidate the affected providers post-import.